### PR TITLE
fix(windows): fall back to Get-CimInstance when wmic is missing (Win11 24H2+)

### DIFF
--- a/src/process-tree.js
+++ b/src/process-tree.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const os = require('os');
 
 const platform = os.platform();
@@ -226,7 +226,15 @@ class ProcessTree {
     try {
       output = execSync(
         'wmic process get ProcessId,ParentProcessId,CommandLine,WorkingSetSize,CreationDate /format:csv',
-        { encoding: 'utf-8', timeout: 15000, maxBuffer: 10 * 1024 * 1024 }
+        {
+          encoding: 'utf-8',
+          timeout: 15000,
+          maxBuffer: 10 * 1024 * 1024,
+          // Silence the "'wmic' is not recognized" stderr on Windows builds where
+          // wmic was removed — fromWindows() falls back to fromCIM() in that case.
+          stdio: ['ignore', 'pipe', 'ignore'],
+          windowsHide: true,
+        }
       );
     } catch {
       return new ProcessTree([]);
@@ -291,13 +299,100 @@ class ProcessTree {
   }
 
   /**
+   * Windows: build ProcessTree via Get-CimInstance (PowerShell).
+   *
+   * `wmic` is deprecated and is being removed from Windows — it is absent by
+   * default on Windows 11 24H2+ / Server 2025, where fromWMIC() silently returns
+   * an empty tree and zclean reports "0 zombies". Get-CimInstance is the supported
+   * replacement and ships in-box on every supported Windows (PowerShell 5.1+).
+   * Emits the same shape as fromWMIC()/fromPS(): {pid, ppid, cmd, mem, age, startTime}.
+   *
+   * @returns {ProcessTree}
+   */
+  static fromCIM() {
+    let output;
+    try {
+      // Built as one PowerShell pipeline; passed via -EncodedCommand to avoid any
+      // shell-quoting issues with the embedded script/format expressions.
+      const ps =
+        '$ProgressPreference=\'SilentlyContinue\';' + // suppress CLIXML progress on stderr
+        'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,' +
+        'CommandLine,WorkingSetSize,@{n=\'Created\';e={if($_.CreationDate){' +
+        '$_.CreationDate.ToUniversalTime().ToString(\'o\')}else{\'\'}}} | ConvertTo-Json -Compress';
+      const encoded = Buffer.from(ps, 'utf16le').toString('base64');
+      // execFileSync (no shell) — args passed as an array, nothing is interpolated
+      // into a shell command string.
+      output = execFileSync(
+        'powershell.exe',
+        ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
+        { encoding: 'utf-8', timeout: 15000, maxBuffer: 32 * 1024 * 1024, windowsHide: true }
+      );
+    } catch {
+      return new ProcessTree([]);
+    }
+
+    let rows;
+    try {
+      rows = JSON.parse(output);
+    } catch {
+      return new ProcessTree([]);
+    }
+    if (!Array.isArray(rows)) rows = [rows]; // ConvertTo-Json emits a bare object for 1 row
+
+    const processes = [];
+    const myPid = process.pid;
+
+    for (const r of rows) {
+      const pid = parseInt(r.ProcessId, 10);
+      const cmd = r.CommandLine || '';
+      if (isNaN(pid) || pid === myPid || !cmd) continue;
+
+      const ppid = parseInt(r.ParentProcessId, 10);
+
+      let ageMs = 0;
+      let startTime = null;
+      if (r.Created) {
+        const dt = new Date(r.Created);
+        if (!isNaN(dt.getTime())) {
+          startTime = dt.toISOString();
+          ageMs = Date.now() - dt.getTime();
+        }
+      }
+
+      processes.push({
+        pid,
+        ppid: isNaN(ppid) ? 0 : ppid,
+        cmd,
+        mem: parseInt(r.WorkingSetSize, 10) || 0,
+        age: ageMs,
+        startTime,
+      });
+    }
+
+    return new ProcessTree(processes);
+  }
+
+  /**
+   * Windows factory: prefer `wmic` (fast, present on older Windows), fall back to
+   * Get-CimInstance when wmic is missing or yields nothing. Keeps the existing fast
+   * path where wmic still exists while fixing machines where it was removed.
+   *
+   * @returns {ProcessTree}
+   */
+  static fromWindows() {
+    const tree = ProcessTree.fromWMIC();
+    if (tree.byPid.size > 0) return tree;
+    return ProcessTree.fromCIM();
+  }
+
+  /**
    * Platform-aware factory. Use this from scanner/orphan/whitelist.
-   * Calls fromWMIC() on Windows, fromPS() everywhere else.
+   * Windows → wmic with Get-CimInstance fallback; otherwise fromPS().
    *
    * @returns {ProcessTree}
    */
   static build() {
-    return platform === 'win32' ? ProcessTree.fromWMIC() : ProcessTree.fromPS();
+    return platform === 'win32' ? ProcessTree.fromWindows() : ProcessTree.fromPS();
   }
 }
 

--- a/test/process-tree.test.js
+++ b/test/process-tree.test.js
@@ -33,6 +33,33 @@ describe('ProcessTree', () => {
     });
   });
 
+  // ── fromWindows / fromCIM (Windows enumeration) ─────────────────
+  describe('fromWindows / fromCIM', () => {
+    it('fromWindows returns a ProcessTree without throwing on any platform', () => {
+      assert.ok(ProcessTree.fromWindows() instanceof ProcessTree);
+    });
+
+    it('fromCIM returns a ProcessTree without throwing on any platform', () => {
+      assert.ok(ProcessTree.fromCIM() instanceof ProcessTree);
+    });
+
+    if (process.platform === 'win32') {
+      it('fromCIM enumerates live processes on Windows (no wmic required)', () => {
+        const tree = ProcessTree.fromCIM();
+        assert.ok(tree.byPid.size > 0, 'CIM tree should contain processes');
+      });
+
+      it('build() yields a non-empty tree on Windows (wmic or CIM fallback)', () => {
+        const tree = ProcessTree.build();
+        assert.ok(tree.byPid.size > 0, 'build() must enumerate processes on Windows');
+      });
+
+      it('fromCIM excludes its own PID', () => {
+        assert.equal(ProcessTree.fromCIM().get(process.pid), null);
+      });
+    }
+  });
+
   // ── get(pid) ────────────────────────────────────────────────────
   describe('get', () => {
     it('returns process info for existing PID', () => {


### PR DESCRIPTION
Fixes #6.

## Problem

`wmic` is gone by default on Windows 11 24H2+ / Server 2025. `ProcessTree.fromWMIC()` then returns an empty tree, so zclean reports "0 zombies" and never cleans anything on those machines. CI runs only `ubuntu-latest` / `macos-latest`, so this path was never exercised.

## Change

- **`ProcessTree.fromCIM()`** — enumerate via `Get-CimInstance Win32_Process` (PowerShell), producing the exact same `{pid, ppid, cmd, mem, age, startTime}` shape as `fromWMIC()` / `fromPS()`.
  - Invoked with `execFileSync` (no shell) + `-EncodedCommand` (no quoting issues).
  - `$ProgressPreference='SilentlyContinue'` keeps stderr clean.
- **`ProcessTree.fromWindows()`** — try `fromWMIC()` first (keeps the existing fast path where wmic is still present), fall back to `fromCIM()` when wmic is missing or yields nothing.
- `build()` now calls `fromWindows()` on win32. The non-Windows (`fromPS`) path is unchanged.
- Silence the `'wmic' is not recognized` stderr leak in `fromWMIC()` so the fallback probe is quiet.
- Tests: platform-aware `fromWindows` / `fromCIM` cases (cross-platform "doesn't throw" + win32-only live-enumeration assertions).

## Verification (Windows 11, build 26200, no wmic)

```
fromWMIC size = 0      # no wmic
fromCIM  size = 587    # PowerShell CIM works
build()  size = 587    # falls back to CIM
```

`node --test` is green except the pre-existing unix-only `fromPS` live test (which passes on the ubuntu/macos CI).

## Notes

- Kept `wmic` as the primary Windows path to preserve current behaviour/perf; happy to make CIM the default and drop wmic entirely if you'd prefer (wmic is end-of-life).
- Consider adding `windows-latest` to the CI matrix — it would have caught this. The `fromPS` live test would need a unix guard first.
